### PR TITLE
removed Preact pragmas and imports

### DIFF
--- a/chart-comps/BarChart.tsx
+++ b/chart-comps/BarChart.tsx
@@ -1,5 +1,4 @@
-/** @jsx h */
-import { h, Fragment, useEffect, d3 } from "../mod.ts";
+import { useEffect, d3 } from "../mod.ts";
 import { BarChartProps } from "../chart-props/BarChartProps.ts";
 
 // need to work on paddings that dynamically update to avoid overlapping with the graph

--- a/chart-comps/ChoroplethChart.tsx
+++ b/chart-comps/ChoroplethChart.tsx
@@ -1,5 +1,4 @@
-/** @jsx h */
-import { h, Fragment, render, d3 } from "../mod.ts";
+import { d3 } from "../mod.ts";
 import { useEffect, useState }from "../mod.ts";
 import { ChoroplethProps } from "../chart-props/ChoroplethProps.ts";
 

--- a/chart-comps/DonutChart.tsx
+++ b/chart-comps/DonutChart.tsx
@@ -1,5 +1,4 @@
-/** @jsx h */
-import { h, useEffect, Fragment, d3 } from "../mod.ts";
+import { useEffect, d3 } from "../mod.ts";
 import { DonutChartProps } from "../chart-props/DonutChartProps.ts";
 
 export default function DonutChart(props: DonutChartProps) {

--- a/chart-comps/LineChart.tsx
+++ b/chart-comps/LineChart.tsx
@@ -1,6 +1,4 @@
-// deno-lint-ignore-file
-/** @jsx h */
-import { h, Fragment, useEffect, d3 } from "../mod.ts";
+import { useEffect, d3 } from "../mod.ts";
 import { LineChartProps } from "../chart-props/LineChartProps.ts";
 
 export default function LineChart2(props: LineChartProps) {

--- a/chart-comps/PieChart.tsx
+++ b/chart-comps/PieChart.tsx
@@ -1,5 +1,4 @@
-/** @jsx h */
-import { h, Fragment, useEffect, d3 } from "../mod.ts";
+import { useEffect, d3 } from "../mod.ts";
 import { PieChartProps } from "../chart-props/PieChartProps.ts";
 
 // exporting PieChart

--- a/chart-comps/ScatterPlotChart.tsx
+++ b/chart-comps/ScatterPlotChart.tsx
@@ -1,5 +1,4 @@
-/** @jsx h */
-import { h, Fragment, d3, useEffect } from "../mod.ts";
+import { d3, useEffect } from "../mod.ts";
 import { ScatterChartProps } from "../chart-props/ScatterChartProps.ts";
 
 export default function ScatterPlotChart(props: ScatterChartProps) {

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,3 @@
 export * as d3 from "https://esm.sh/d3@7.6.1?dev";
-export { h, Fragment,render } from "https://esm.sh/preact@10.8.2";
+export { render } from "https://esm.sh/preact@10.8.2";
 export { useEffect,useState } from "https://esm.sh/preact@10.8.2/hooks";


### PR DESCRIPTION
 Removed Preact pragmas and imports to fix an issue caused by Fresh's 1.1 update making Preact jsx support automatic. Fresh projects cannot support having both manual pragma declarations/imports and automatic jsx support in the same codebase, making it necessary to change it here so devs don't have to do extra work in their other files just because they want to use this library.